### PR TITLE
Fix to allow multiple + signs in query parameter

### DIFF
--- a/fss/11.4/src/controller.js
+++ b/fss/11.4/src/controller.js
@@ -275,7 +275,7 @@ export default class {
           var key = decodeURIComponent(tpl[0]);
           var value = '';
           if (tpl.length > 1) {
-            value = decodeURIComponent(tpl[1].replace('+', '%20', 'g'));
+            value = decodeURIComponent(tpl[1].replace(new RegExp("\\+", 'g'), '%20'));
           }
 
           if (params[key] === undefined) {


### PR DESCRIPTION
This is a bug and only the first + symbol and second are replaced with "%20" and any subsequent ones are left as a + symbol. This fix replaces all + symbols with "%20"